### PR TITLE
hip: remove include of hip_runtime.h

### DIFF
--- a/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/HostDevDef.h
+++ b/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/HostDevDef.h
@@ -22,7 +22,7 @@
    #include "cuda_runtime.h"
  #endif
  #if defined(HIP_TARGET_AMD)
-   #include "hip_runtime.h"
+//   #include "hip_runtime.h"
  #endif
  #define __DEVICE__  __device__
  #define __HOST__    __host__


### PR DESCRIPTION

with ROCM v5, hipcc isn't finding `hip_runtime.h` in the default include path. But then again, we don't need it, so easier to just remove it.
