### PR TITLE
fix exec stack warning from ld

### DIFF
--- a/FastCaloSimAnalyzer/FastCaloGpu/src/CMakeLists.txt
+++ b/FastCaloSimAnalyzer/FastCaloGpu/src/CMakeLists.txt
@@ -154,7 +154,7 @@ if(USE_STDPAR)
     
   endif()
     
-  target_link_options(${FastCaloGpu_LIB} PRIVATE ${STDPAR_DIRECTIVE})
+  target_link_options(${FastCaloGpu_LIB} PRIVATE ${STDPAR_DIRECTIVE} -Xlinker -z noexecstack)
 
 endif()
 

--- a/FastCaloSimAnalyzer/FastCaloSimCommon/cmake/Helpers.cmake
+++ b/FastCaloSimAnalyzer/FastCaloSimCommon/cmake/Helpers.cmake
@@ -70,7 +70,7 @@ function(fcs_make_task)
 
   if(USE_STDPAR)
     target_compile_options(${_target} PRIVATE ${STDPAR_DIRECTIVE})
-    target_link_options(${_target} PRIVATE ${STDPAR_DIRECTIVE})
+    target_link_options(${_target} PRIVATE ${STDPAR_DIRECTIVE} -Xlinker -z noexecstack)
   endif()
   
   foreach(_dependency ${ARG_DEPENDENCY})


### PR DESCRIPTION
Recent versions of ld have a new security feature to prevent stack execution, leading to warning messages such as:
```
/opt/binutils/2.43.1_gcc132/bin/ld: warning: /tmp/pgcudafatESF4A7ROIYJW.o: missing .note.GNU-stack section implies executable stack
/opt/binutils/2.43.1_gcc132/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```

This fix suppresses these warning