### PR TITLE
add new executable runTFCSStdPar to test stdpar features

### DIFF
--- a/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/CountingIterator.h
+++ b/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/CountingIterator.h
@@ -1,3 +1,10 @@
+#ifndef COUNTING_ITERATOR_H
+#define COUNTING_ITERATOR_H 1
+
+#include <cstddef>
+#include <type_traits>
+#include <iterator>
+
 struct counting_iterator {
 
   typedef size_t Index_t;
@@ -67,3 +74,6 @@ public:
 private:
   value_type value;
 };
+
+
+#endif

--- a/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/TestStdPar.h
+++ b/FastCaloSimAnalyzer/FastCaloGpu/FastCaloGpu/TestStdPar.h
@@ -1,0 +1,16 @@
+#ifndef FCS_TEST_STDPAR
+#define FCS_TEST_STDPAR 1
+
+class TestStdPar {
+
+public:
+
+  void testAll(unsigned long);
+
+  void test_vector(unsigned long);
+  void test_atomicAdd_int(unsigned long);
+  void test_atomicAdd_float(unsigned long);
+  
+};
+
+#endif

--- a/FastCaloSimAnalyzer/FastCaloGpu/src/CMakeLists.txt
+++ b/FastCaloSimAnalyzer/FastCaloGpu/src/CMakeLists.txt
@@ -57,7 +57,7 @@ endif()
 
 # Sources
 if(USE_STDPAR)
-  set(FastCaloGpu_Srcs GeoLoadGpu.cxx KernelWrapper_sp.cxx Rand4Hits_sp.cxx)
+  set(FastCaloGpu_Srcs GeoLoadGpu.cxx KernelWrapper_sp.cxx Rand4Hits_sp.cxx TestStdPar.cxx)
   if ( ${STDPAR_TARGET} STREQUAL "gpu" )
     set(FastCaloGpu_Srcs ${FastCaloGpu_Srcs} gpuQ.cu )
   endif()

--- a/FastCaloSimAnalyzer/FastCaloGpu/src/TestStdPar.cxx
+++ b/FastCaloSimAnalyzer/FastCaloGpu/src/TestStdPar.cxx
@@ -1,0 +1,85 @@
+#include "TestStdPar.h"
+#include "CountingIterator.h"
+
+#include <algorithm>
+#include <execution>
+#include <iostream>
+#include <vector>
+#include <atomic>
+
+void TestStdPar::testAll(unsigned long num) {
+  test_vector(num);
+  test_atomicAdd_int(num);
+  test_atomicAdd_float(num);
+}
+
+void TestStdPar::test_vector(unsigned long num) {
+
+    std::cout << "---------- test_vec( " << num << " ) -------------\n";
+
+    std::vector<float>* pvec = new std::vector<float>;
+    pvec->resize(num);
+
+    float* pdat = pvec->data();
+
+    for (int i=0; i<num; ++i) {
+      pdat[i] = float(i) / 100.;
+      if (i<10) { printf("vec test CPU: %d %f\n", i, pdat[i]); }
+    }
+
+    std::for_each_n(std::execution::par_unseq, counting_iterator(0), num,
+                    [=](int i) {
+                      if (i<10) { printf("vec test GPU: %d %f\n", i, pdat[i]); }
+                      pdat[i] += 1.;
+                    } );
+
+    delete pvec;
+    
+    std::cout << "------- done test_vec(num) -------------\n";
+    
+  }
+    
+  
+void TestStdPar::test_atomicAdd_int(unsigned long num) {
+    std::cout << "---------- test_atomic<int>_add -------------\n";
+    std::atomic<int> *ii = new std::atomic<int>{0};
+    std::for_each_n(std::execution::par_unseq, counting_iterator(0), num,
+                    [=](int i) {
+                      int j = (*ii)++;
+                      printf("%d %d\n",i,j);
+                    } );
+    std::cout << "   after loop: " << *ii << " (should be " << num << ")" <<std::endl;
+    std::cout << "---------- done test_atomic<int>_add -------------\n\n";
+  }
+
+  /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void TestStdPar::test_atomicAdd_float(unsigned long N) {
+    std::cout << "---------- test_atomicAdd_float -------------\n";
+    
+    float ta[N]{0.}, tc[N]{0.};
+    for (int i=0; i<N; ++i) {
+      ta[i%2] += i;
+      tc[i] += i;
+    }
+
+    
+    float *fa = new float[N];
+    float *fb = new float[N];
+    float *fc = new float[N];
+    std::for_each_n(std::execution::par_unseq, counting_iterator(0), N,
+                    [=] (int i) {
+                      fb[i%2] += i;
+#if defined ( _NVHPC_STDPAR_NONE ) || defined ( _NVHPC_STDPAR_MULTICORE )
+                      fa[i % 2] += i;
+                      fc[i] += i;
+#else
+                      atomicAdd(&fa[i%2],float(i));
+                      atomicAdd(&fc[i],float(i));
+#endif
+                    });
+    for (int i=0; i<N; ++i) {
+      printf("%d : %2g [%2g] %g  %g [%g]\n",i, fa[i], ta[i], fb[i], fc[i], tc[i]);
+    }
+    std::cout << "---------- done test_atomicAdd_float -------------\n\n";
+  }

--- a/FastCaloSimAnalyzer/FastCaloSimAnalyzer/TFCSStdParTest.h
+++ b/FastCaloSimAnalyzer/FastCaloSimAnalyzer/TFCSStdParTest.h
@@ -1,0 +1,10 @@
+#ifndef TFCSSTDPARTEST_H
+#define TFCSSTDPARTEST_H 1
+
+class TFCSStdParTest {
+public:
+  void test(bool doAtomic, bool doVector, unsigned long num);
+};
+
+
+#endif

--- a/FastCaloSimAnalyzer/Root/CMakeLists.txt
+++ b/FastCaloSimAnalyzer/Root/CMakeLists.txt
@@ -22,6 +22,10 @@ set(FastCaloSimAnalyzer_Srcs
   TFCSWriteCellsToTree.cxx
 )
 
+if(USE_STDPAR)
+  set(FastCaloSimAnalyzer_Srcs ${FastCaloSimAnalyzer_Srcs} TFCSStdParTest.cxx)
+endif()
+
 # # Global include is needed for dictionary generation to work
 include_directories(../)
 

--- a/FastCaloSimAnalyzer/Root/TFCSStdParTest.cxx
+++ b/FastCaloSimAnalyzer/Root/TFCSStdParTest.cxx
@@ -1,0 +1,17 @@
+#include "FastCaloSimAnalyzer/TFCSStdParTest.h"
+#include "FastCaloGpu/TestStdPar.h"
+
+#include <iostream>
+
+void TFCSStdParTest::test(bool doAtomic, bool doVector, unsigned long num) {
+
+  TestStdPar tst;
+
+  if (doAtomic) {
+    tst.test_atomicAdd_int(num);
+    tst.test_atomicAdd_float(num);
+  }
+
+  if (doVector) tst.test_vector(num);
+  
+}

--- a/FastCaloSimAnalyzer/macro/CMakeLists.txt
+++ b/FastCaloSimAnalyzer/macro/CMakeLists.txt
@@ -47,3 +47,13 @@ fcs_make_task(runTFCSSimulation
   DEPENDENCY ${AthenaStandalone_LIB}
   DEPENDENCY ${FastCaloSimAnalyzer_LIB}
 )
+
+if(USE_STDPAR)
+  message(STATUS "Building StdPar tests")
+  fcs_make_task(runTFCSStdParTest
+    SOURCE runTFCSStdParTest.cxx
+    DEPENDENCY ${FastCaloSimCommon_LIB}
+    DEPENDENCY ${AthenaStandalone_LIB}
+    DEPENDENCY ${FastCaloSimAnalyzer_LIB}
+    )
+endif()

--- a/FastCaloSimAnalyzer/macro/runTFCSStdParTest.cxx
+++ b/FastCaloSimAnalyzer/macro/runTFCSStdParTest.cxx
@@ -1,0 +1,37 @@
+#include <cstdio>
+#include <map>
+#include <iostream>
+#include "citer.h"
+#include <docopt/docopt.h>
+
+#include "FastCaloSimAnalyzer/TFCSStdParTest.h"
+
+static const char* USAGE =
+    R"(Run test for stdpar
+
+Usage:
+  runTFCSStdParTest [--doAtomicTest] [--doVectorTest] [-n <size> | --num <size>]
+  runTFCSStdParTest (-h | --help)
+
+Options:
+  -h --help                    Show help screen.
+  --doAtomicTest               Do test for atomic increments [default: false].
+  --doVectorTest               Do test for allocating/accessing vector<float> [default: false].
+  -n <size> --num <size>       Size of array to allocate for tests [default: 10].
+)";
+
+
+int main( int argc, char** argv ) {
+
+  std::map<std::string, docopt::value> args = docopt::docopt( USAGE, {argv + 1, argv + argc}, true );
+
+  bool doAtomic = args["--doAtomicTest"].asBool();
+  bool doVec    = args["--doVectorTest"].asBool();
+  int  num      = args["--num"].asLong();
+  
+  TFCSStdParTest test;
+
+  test.test(doAtomic,doVec,num);
+
+  return 0;
+}


### PR DESCRIPTION

add a new executable that tests some feature in stdpar. The executable runTFCSStdParTest is in macro, and tests are in FastCaloGpu, so the executable is linked to the bit that does the stdpar as a shared lib.

The tests are only built if -DUSE_STDPAR=ON is chosen at cmake config.