### PR TITLE
improve gcc version parsing

### DIFF
--- a/scripts/nvc++_p
+++ b/scripts/nvc++_p
@@ -9,7 +9,7 @@ A=$*
 ## > makelocalrc -gcc PATH_TO_GCC -gpp PATH_TO_G++ -x -d PATH_TO_LOCALRC_DIR
 #
 if [[ -z ${NVHPC_LOCALRC+x} ]]; then
-    GCCVER=$( gcc --version | head -1 | awk '{print $NF}' | sed s/'\.'//g | sed s/.$// )
+    GCCVER=$( gcc --version | head -1 | awk '{print $NF}' | sed s/'\.'/\ /g | awk '{print $1$2}' )
     NVHPC_LOCALRC="${NVHPC_ROOT}/compilers/bin/localrc_gcc${GCCVER}"
 fi
 


### PR DESCRIPTION
fixes gcc version parsing for stdpar rclocal file to only use the major and minor numbers of the gcc version and ignore everything that comes after.